### PR TITLE
Use only BIO_METHOD pointer in openssl >= 1.1.0

### DIFF
--- a/libretroshare/src/tcponudp/bss_tou.c
+++ b/libretroshare/src/tcponudp/bss_tou.c
@@ -99,6 +99,8 @@ static int  BIO_get_init(BIO *a) { return a->init; }
 static int  BIO_get_shutdown(BIO *a) { return a->shutdown; }
 static void BIO_set_init(BIO *a,int i) { a->init=i; }
 static void BIO_set_data(BIO *a,void *p) { a->ptr = p; }
+long (*BIO_meth_get_ctrl(const BIO_METHOD* biom)) (BIO*, int, long, void*)
+{ return biom->ctrl; }
 
 #endif
 
@@ -116,27 +118,35 @@ static BIO_METHOD methods_tou_sockp =
     NULL,
 };
 
-#else
-
-static BIO_METHOD methods_tou_sockp =
-        BIO_meth_new(BIO_TYPE_TOU_SOCKET, "tou_socket");
-
-BIO_meth_set_write(&methods_tou_sockp, tou_socket_write);
-BIO_meth_set_read(&methods_tou_sockp, tou_socket_read);
-BIO_meth_set_puts(&methods_tou_sockp, tou_socket_puts);
-BIO_meth_set_ctrl(&methods_tou_sockp, tou_socket_ctrl);
-BIO_meth_set_create(&methods_tou_sockp,tou_socket_new);
-BIO_meth_set_destroy(&methods_tou_sockp,tou_socket_free);
-
-#endif
-
-BIO_METHOD *BIO_s_tou_socket(void)
+BIO_METHOD* BIO_s_tou_socket(void)
 {
 #ifdef DEBUG_TOU_BIO
 	fprintf(stderr, "BIO_s_tou_socket(void)\n");
 #endif
 	return(&methods_tou_sockp);
 }
+
+#else
+
+BIO_METHOD* BIO_s_tou_socket(void)
+{
+	static BIO_METHOD* methods_tou_sockp_ptr = NULL;
+	if(!methods_tou_sockp_ptr)
+	{
+		 methods_tou_sockp_ptr = BIO_meth_new(BIO_TYPE_TOU_SOCKET, "tou_socket");
+
+		BIO_meth_set_write(   methods_tou_sockp_ptr, tou_socket_write );
+		BIO_meth_set_read(    methods_tou_sockp_ptr, tou_socket_read  );
+		BIO_meth_set_puts(    methods_tou_sockp_ptr, tou_socket_puts  );
+		BIO_meth_set_ctrl(    methods_tou_sockp_ptr, tou_socket_ctrl  );
+		BIO_meth_set_create(  methods_tou_sockp_ptr, tou_socket_new   );
+		BIO_meth_set_destroy( methods_tou_sockp_ptr, tou_socket_free  );
+	}
+
+	return methods_tou_sockp_ptr;
+}
+
+#endif
 
 BIO *BIO_new_tou_socket(int fd, int close_flag)
 	{
@@ -257,17 +267,17 @@ static long tou_socket_ctrl(BIO *b, int cmd, long num, void *ptr)
 		break;
 	case BIO_C_SET_FD:
 		tou_socket_free(b);
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 
 		break;
 	case BIO_C_GET_FD:
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_GET_CLOSE:
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_SET_CLOSE:
-		ret = BIO_s_fd()->ctrl(b,cmd,num,ptr) ;
+		ret = BIO_meth_get_ctrl(BIO_s_fd())(b,cmd,num,ptr);
 		break;
 	case BIO_CTRL_PENDING:
 		ret = tou_maxread(BIO_get_fd(b,NULL));

--- a/libretroshare/src/tcponudp/tou.h
+++ b/libretroshare/src/tcponudp/tou.h
@@ -103,11 +103,6 @@ int 	tou_connect(int sockfd, const struct sockaddr *serv_addr,
 					socklen_t addrlen, uint32_t conn_period);
 int 	tou_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);		
 
-/// for relay connections
-int tou_connect_via_relay( int sockfd, const sockaddr_in& own_addr,
-                           const sockaddr_in& proxy_addr,
-                           const sockaddr_in& dest_addr );
-
 /* non-standard bonuses */
 int	tou_connected(int sockfd);
 int 	tou_listenfor(int sockfd, const struct sockaddr *serv_addr, socklen_t addrlen);
@@ -130,6 +125,14 @@ int	tou_maxwrite(int sockfd);
 
 #ifdef  __cplusplus
 }
+
+typedef struct sockaddr_in sockaddr_in;
+
+/// for relay connections
+int tou_connect_via_relay( int sockfd, const sockaddr_in& own_addr,
+                           const sockaddr_in& proxy_addr,
+                           const sockaddr_in& dest_addr );
+
 #endif
 #endif
 


### PR DESCRIPTION
The type declaration is hidden so we can't declare variable but only
pointers
Fix compilation on Android