### PR TITLE
More fixes in JSON API

### DIFF
--- a/jsonapi-generator/src/async-method-wrapper-template.cpp.tmpl
+++ b/jsonapi-generator/src/async-method-wrapper-template.cpp.tmpl
@@ -18,8 +18,8 @@
  *                                                                             *
  *******************************************************************************/
 
-registerHandler("$%apiPath%$",
-		[this, $%captureVars%$](const std::shared_ptr<rb::Session> session)
+registerHandler( "$%apiPath%$",
+                 [this](const std::shared_ptr<rb::Session> session)
 {
 	const std::multimap<std::string, std::string> headers
 	{
@@ -29,7 +29,7 @@ registerHandler("$%apiPath%$",
 	session->yield(rb::OK, headers);
 
 	size_t reqSize = session->get_request()->get_header("Content-Length", 0);
-	session->fetch( reqSize, [this, $%captureVars%$](
+	session->fetch( reqSize, [this](
 					const std::shared_ptr<rb::Session> session,
 					const rb::Bytes& body )
 	{
@@ -74,5 +74,4 @@ $%outputParamsSerialization%$
 		session->yield(message.str());
 		$%sessionDelayedClose%$
 	} );
-}, $%requiresAuth%$);
-
+}, $%requiresAuth%$ );

--- a/jsonapi-generator/src/method-wrapper-template.cpp.tmpl
+++ b/jsonapi-generator/src/method-wrapper-template.cpp.tmpl
@@ -18,8 +18,8 @@
  *                                                                             *
  *******************************************************************************/
 
-registerHandler("$%apiPath%$",
-				[$%captureVars%$](const std::shared_ptr<rb::Session> session)
+registerHandler( "$%apiPath%$",
+                 [](const std::shared_ptr<rb::Session> session)
 {
 	size_t reqSize = session->get_request()->get_header("Content-Length", 0);
 	session->fetch( reqSize, [](
@@ -46,5 +46,5 @@ $%outputParamsSerialization%$
 		// return them to the API caller
 		DEFAULT_API_CALL_JSON_RETURN(rb::OK);
 	} );
-}, $%requiresAuth%$);
+}, $%requiresAuth%$ );
 


### PR DESCRIPTION
Schedule delayed async session closing properly (without recurrence)
Fix double capture of this in async method registering, that was causing
  compilation error for Android
Fix minor compiler warning in jsonapi-generator